### PR TITLE
Fingerprint - rename variable in vulnerable path

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -47,10 +47,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
         return furBall(myUrl);
     }
 
-    protected AttackResult furBall(String theUrl) {
-        if (theUrl.matches("http://ifconfig.pro")) {
+    protected AttackResult furBall(String url) {
+        if (url.matches("http://ifconfig.pro")) {
             String html;
-            try (InputStream in = new URL(theUrl).openStream()) {
+            try (InputStream in = new URL(url).openStream()) {
                 html = new String(in.readAllBytes(), StandardCharsets.UTF_8)
                         .replaceAll("\n","<br>"); // Otherwise the \n gets escaped in the response
             } catch (MalformedURLException e) {

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -47,10 +47,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
         return furBall(myUrl);
     }
 
-    protected AttackResult furBall(String url) {
-        if (url.matches("http://ifconfig.pro")) {
+    protected AttackResult furBall(String theUrl) {
+        if (theUrl.matches("http://ifconfig.pro")) {
             String html;
-            try (InputStream in = new URL(url).openStream()) {
+            try (InputStream in = new URL(theUrl).openStream()) {
                 html = new String(in.readAllBytes(), StandardCharsets.UTF_8)
                         .replaceAll("\n","<br>"); // Otherwise the \n gets escaped in the response
             } catch (MalformedURLException e) {

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -43,8 +43,8 @@ public class SSRFTask2 extends AssignmentEndpoint {
 
     @PostMapping("/SSRF/task2")
     @ResponseBody
-    public AttackResult completed(@RequestParam String url) {
-        return furBall(url);
+    public AttackResult completed(@RequestParam String myUrl) {
+        return furBall(myUrl);
     }
 
     protected AttackResult furBall(String url) {

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -47,10 +47,10 @@ public class SSRFTask2 extends AssignmentEndpoint {
         return furBall(myUrl);
     }
 
-    protected AttackResult furBall(String url) {
-        if (url.matches("http://ifconfig.pro")) {
+    protected AttackResult furBall(String myUrl) {
+        if (myUrl.matches("http://ifconfig.pro")) {
             String html;
-            try (InputStream in = new URL(url).openStream()) {
+            try (InputStream in = new URL(myUrl).openStream()) {
                 html = new String(in.readAllBytes(), StandardCharsets.UTF_8)
                         .replaceAll("\n","<br>"); // Otherwise the \n gets escaped in the response
             } catch (MalformedURLException e) {


### PR DESCRIPTION
Testing out changing line of code with vulnerable sink will close old / open new finding

We utilize a [hashing mechanism to detect duplicate alerts using fingerprints](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#preventing-duplicate-alerts-using-fingerprints).  In the scenario the alert is being detected as new (and closing the old) as the hash of the source code line in which the result is located has changed.  As mentioned in the linked article - this script highlights how this hash is calculated: https://github.com/github/codeql-action/blob/main/src/fingerprints.ts

# Results
- Alerts 
   - [Old Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/40) Closed
   - [New Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/45) Created

- [REVERTED](https://github.com/vulna-felickz/WebGoat/pull/1/commits/71bef7065d7a34b87892d68bafeb8dce3d1eb890) change back to original
   - [Old Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/40) was again detected (would be reopened)
   - [New Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/45) was closed out

- Sarif Changes 
   -  primaryLocationLineHash
- Sarif Remains same
   -  primaryLocationStartColumnFingerprint

![image](https://user-images.githubusercontent.com/1760475/174160436-9fc4bf92-a5c4-4c5c-b1ee-d9b332734945.png)
