### PR TITLE
Authenticate to private maven package repository (s4u/maven-settings-action)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -90,6 +90,11 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       
+    - name: echo
+      run: |
+        echo "${{github.workspace}}"
+        echo "/home/runner/work/${{ github.event.repository.name }}/"
+      
     - uses: actions/upload-artifact@v3
       with:        
-        path: "results/*.sarif"
+        path: "${{github.workspace}}/results/*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,5 @@
 # For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
+# to commit it to your repository. 
 #
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -69,7 +69,7 @@ jobs:
     #   echo "Run, Build Application using script"
     #   ./location_of_script_within_repo/buildscript.sh
     
-    - if: matrix.language == 'java'  
+    - if: matrix.language == 'java'
       name: Set up java 17
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -93,4 +93,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:        
         name: sarif-results
-        path: "/home/runner/work/${{ github.event.repository.name }}/results/*.sarif"
+        path: "${{ runner.workspace }}/results/*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -89,12 +89,5 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      
-    - name: echo
-      run: |
-        echo "${{github.workspace}}"
-        echo "/home/runner/work/${{ github.event.repository.name }}/"
-      
+        
     - uses: actions/upload-artifact@v3
-      with:        
-        path: "${{github.workspace}}/results/*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,6 +76,12 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           architecture: x64
+          
+    - if: matrix.language == 'java'
+      name: Configure maven credentials
+      uses: s4u/maven-settings-action@v2.6.0
+      with:
+        servers: '[{"id": "central", "username": "felickz2", "password": "${{ secrets.VULNA_FELICKZ2_FEED }}"}]'
         
     - if: matrix.language == 'java' 
       name: Build with Maven

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -89,5 +89,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-        
+      
     - uses: actions/upload-artifact@v3
+      with:        
+        path: "/home/runner/work/${{ github.event.repository.name }}/"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,4 +92,5 @@ jobs:
       
     - uses: actions/upload-artifact@v3
       with:        
+        name: sarif-results
         path: "/home/runner/work/${{ github.event.repository.name }}/results/*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,4 +92,4 @@ jobs:
       
     - uses: actions/upload-artifact@v3
       with:        
-        path: "*.sarif"
+        path: "results/*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -89,3 +89,7 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+      
+    - uses: actions/upload-artifact@v3
+      with:        
+        path: "*.sarif"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -92,4 +92,4 @@ jobs:
       
     - uses: actions/upload-artifact@v3
       with:        
-        path: "/home/runner/work/${{ github.event.repository.name }}/"
+        path: "/home/runner/work/${{ github.event.repository.name }}/results/*.sarif"

--- a/pom.xml
+++ b/pom.xml
@@ -675,8 +675,8 @@
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>central</id>
-            <url>https://repo.maven.apache.org/maven2</url>
+            <id>vulna-felickz2-feed</id>
+            <url>https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -663,7 +663,7 @@
 
     <repositories>
         <repository>
-          <id>vulna-felickz2-feed</id>
+          <id>central</id>
           <url>https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1</url>
           <releases>
             <enabled>true</enabled>
@@ -675,7 +675,7 @@
     </repositories>
     <pluginRepositories>
         <pluginRepository>
-            <id>vulna-felickz2-feed</id>
+            <id>central</id>
             <url>https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1</url>
             <snapshots>
                 <enabled>false</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -663,11 +663,14 @@
 
     <repositories>
         <repository>
-            <id>central</id>
-            <url>https://repo.maven.apache.org/maven2</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
+          <id>vulna-felickz2-feed</id>
+          <url>https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
Alternative maven example using env vars set to secrets and referencing env vars from settings.xml: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#publishing-using-apache-maven

Testing out private maven package repositories (Azure DevOps Artifact - Maven) from within a Github Actions workflow using CodeQL with a Maven build.  

In [pom.xml](https://github.com/vulna-felickz/WebGoat/blob/2eb6911732bbbc26f041560bf2dbad9dd9d380a0/pom.xml#L666-L667) - overrode the default `central` repository (as described [here](https://stackoverflow.com/a/22081916/343347)) to be my private package repo to reproduce a 401: 
```xml
<repository>
          <id>central</id>
          <url>https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1</url>
          ...
</repository>
```

[Maven Build fails](https://github.com/vulna-felickz/WebGoat/runs/6909161354?check_suite_focus=true) with `status: 401 Unauthorized`
```bash
Run mvn -B package --file pom.xml

2022-06-15T22:28:30.9593299Z [FATAL] Non-resolvable parent POM for org.owasp.webgoat:webgoat:8.2.3-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.6.6 from/to central (https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1): authentication failed for https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1/org/springframework/boot/spring-boot-starter-parent/2.6.6/spring-boot-starter-parent-2.6.6.pom, status: 401 Unauthorized and 'parent.relativePath' points at wrong local POM @ line 11, column 13
```

FIX: use the [maven-settings-action](https://github.com/s4u/maven-settings-action) to override the `settings.xml` ([see step here](https://github.com/vulna-felickz/WebGoat/blob/2eb6911732bbbc26f041560bf2dbad9dd9d380a0/.github/workflows/codeql-analysis.yml#L80-L84))
- Use the `central` repository ID that was specified in POM
- set the credentials from [Action Secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets)

[Build & Package Restore Succeeds](https://github.com/vulna-felickz/WebGoat/runs/6909229677?check_suite_focus=true) 
```bash
[INFO] Downloaded from central: https://pkgs.dev.azure.com/felickz2/vulna-felickz2/_packaging/vulna-felickz2-feed/maven/v1/org/springframework/boot/spring-boot-starter-parent/2.6.6/spring-boot-starter-parent-2.6.6.pom (8.6 kB at 2.5 kB/s)
```