### PR TITLE
Fingerprint - 1char on same line (not impact column of fingerprint)

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -50,8 +50,8 @@ public class SSRFTask2 extends AssignmentEndpoint {
     protected AttackResult furBall(String url) {
         if (url.matches("http://ifconfig.pro")) {
             String html;
-            try (InputStream in = new URL(url).openStream()) {
-                html = new String(in.readAllBytes(), StandardCharsets.UTF_8)
+            try (InputStream is = new URL(url).openStream()) {
+                html = new String(is.readAllBytes(), StandardCharsets.UTF_8)
                         .replaceAll("\n","<br>"); // Otherwise the \n gets escaped in the response
             } catch (MalformedURLException e) {
                 return getFailedResult(e.getMessage());


### PR DESCRIPTION
 - test changing 1char on same line as sink not in the path without impacting `primaryLocationStartColumnFingerprint`

We utilize a [hashing mechanism to detect duplicate alerts using fingerprints](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#preventing-duplicate-alerts-using-fingerprints). In the scenario the alert is being detected as new (and closing the old) as the hash of the source code line in which the result is located has changed. As mentioned in the linked article - this script highlights how this hash is calculated: https://github.com/github/codeql-action/blob/main/src/fingerprints.ts

# Results
- Alerts 
   - [Old Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/40) Closed
   - [New Alert](https://github.com/vulna-felickz/WebGoat/security/code-scanning/47) Created
- Sarif Changes to
   -  primaryLocationLineHash
- Sarif remains the same
   -  primaryLocationStartColumnFingerprint

![image](https://user-images.githubusercontent.com/1760475/174162575-13bb47fc-02b7-4ec0-9253-09b612577808.png)
