### PR TITLE
Fingerprint - add line

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -50,6 +50,7 @@ public class SSRFTask2 extends AssignmentEndpoint {
     protected AttackResult furBall(String url) {
         if (url.matches("http://ifconfig.pro")) {
             String html;
+            String copy = new String(url);
             try (InputStream in = new URL(url).openStream()) {
                 html = new String(in.readAllBytes(), StandardCharsets.UTF_8)
                         .replaceAll("\n","<br>"); // Otherwise the \n gets escaped in the response


### PR DESCRIPTION

We utilize a [hashing mechanism to detect duplicate alerts using fingerprints](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#preventing-duplicate-alerts-using-fingerprints). In the scenario the alert is being detected as new (and closing the old) as the hash of the source code line in which the result is located has changed. As mentioned in the linked article - this script highlights how this hash is calculated: https://github.com/github/codeql-action/blob/main/src/fingerprints.ts

# Results
- Alerts 
   - No new or fixed alerts
- NO Sarif Changes to
   -  `primaryLocationLineHash`
   -  `primaryLocationStartColumnFingerprint`
- Sarif updates to 
   -  `region.startLine`


![image](https://user-images.githubusercontent.com/1760475/174175905-78a8de2a-0061-4763-9a11-5679c922b5d2.png)
